### PR TITLE
Build an additional jar file to allow other projects to use the proxy servlet by inclusion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,8 @@
 					<archive>
 						<manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
+					<attachClasses>true</attachClasses>
+					<classesClassifier>classes</classesClassifier>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Changed the configuration of the maven-war-plugin: added
properties so that an additional jar file named
connectivity.proxy-classes.jar is built. This makes it
possible to include the proxy servlet into other maven
projects.

Maven pom.xml dependency snippet:

```
<dependency>
    <groupId>com.sap.cloudlabs.connectivity</groupId>
    <artifactId>connectivity.proxy</artifactId\>
    <version>0.0.1-SNAPSHOT</version>
    <classifier>classes</classifier>
</dependency>
```
